### PR TITLE
fix small typo on exception message

### DIFF
--- a/src/main/java/net/masterthought/cucumber/ReportParser.java
+++ b/src/main/java/net/masterthought/cucumber/ReportParser.java
@@ -32,7 +32,7 @@ public class ReportParser {
             try (Reader reader = new InputStreamReader(new FileInputStream(jsonFile), Charsets.UTF_8)) {
                 Feature[] features = gson.fromJson(reader, Feature[].class);
                 if (features == null) {
-                    throw new IllegalArgumentException(String.format("File '%s' does not contan features!", jsonFile));
+                    throw new IllegalArgumentException(String.format("File '%s' does not contain features!", jsonFile));
                 }
                 setMetadata(features, jsonFile, i);
 


### PR DESCRIPTION
replace `contan` by `contain` in `"File '%s' does not contan features!"`